### PR TITLE
Don't crash if defaults is not set in scanner section

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -61,14 +61,20 @@ func loadConfig() *config.Config {
 // are added in the order of priority, lowest priority is added first.
 func addScanners(agent agent.Agent, cfg *config.Config) {
 	// go through configured scanners
+	defaultID := ""
 	prio := 0
 	for _, scan := range cfg.Scanner {
 		glog.V(5).Infof("Adding scanner: %v", scan)
 		def, _ := scan.Default.GetSchedule()
+		if scan.Default != nil {
+			defaultID = scan.Default.Id
+		} else {
+			defaultID = ""
+		}
 		// add namespace scanner
 		for _, ns := range scan.Namespace {
 			addScanner(agent, scanner.Config{
-				Id:        scan.Default.Id,
+				Id:        defaultID,
 				Type:      scan.Type,
 				Namespace: ns,
 				Schedule:  def,

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -183,12 +183,23 @@ func TestAddAgents(t *testing.T) {
 					},
 					{
 						Namespace: []string{"batch"},
+						Deployment: []*config.Deployment{
+							{
+								Id:       "",
+								Selector: []string{"app=shell", "app=nightshift"},
+								Schedule: nil,
+							},
+						},
+						Type: "mockscanner",
+					},
+					{
+						Namespace: []string{"batch"},
 						Default:   &config.Default{},
 						Type:      "errorscanner",
 					},
 				},
 			},
-			out: []scinfo{{"mockscanner", 0}, {"mockscanner", 1}, {"mockscanner", 2}, {"mockscanner", 3}, {"mockscanner", 4}},
+			out: []scinfo{{"mockscanner", 0}, {"mockscanner", 1}, {"mockscanner", 2}, {"mockscanner", 3}, {"mockscanner", 4}, {"mockscanner", 5}, {"mockscanner", 6}, {"mockscanner", 7}},
 		},
 	}
 


### PR DESCRIPTION
391395f6 uses scan.Default.Id when adding scanners, although default 
section may not be specified in the config.

Not sure if the tests are correct - I expected this to add just one mockscanner instead of 3