### PR TITLE
WIP Mixin object info in trigger so that it could be used in templates

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -114,7 +114,7 @@ func addTriggers(agent agent.Agent, cfg *config.Config) {
 		if err != nil {
 			glog.Errorf("Error adding trigger: %s", err)
 		} else {
-			trgr.SetConfig(trigger.Config{Id: def.Id, Type: def.Type, Settings: def.Config})
+			trgr.SetConfig(trigger.Config{Id: def.Id, Type: def.Type, Settings: def.Config, Objects: agent.GetObjects()})
 			agent.AddTrigger(def.Id, trgr)
 		}
 	}

--- a/internal/trigger/template.go
+++ b/internal/trigger/template.go
@@ -10,7 +10,23 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/joyrex2001/nightshift/internal/scanner"
 )
+
+func mixinObjects(settings map[string]string, objects map[string]*scanner.Object) map[string]interface{} {
+	templateValues := make(map[string]interface{}, len(settings)+1)
+	for key, element := range settings {
+		templateValues[key] = element
+	}
+	if len(objects) > 0 {
+		templateValues["objects"] = make(map[string]scanner.Object, len(objects))
+		objs, _ := templateValues["objects"].(map[string]scanner.Object)
+		for key, element := range objects {
+			objs[key] = *element
+		}
+	}
+	return templateValues
+}
 
 // RenderTemplate will render provided template. It will return an error if the
 // rendering of the template fails.

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -3,6 +3,8 @@ package trigger
 import (
 	"fmt"
 	"strings"
+
+	"github.com/joyrex2001/nightshift/internal/scanner"
 )
 
 // Trigger defines the public interface of trigger modules.
@@ -15,9 +17,10 @@ type Trigger interface {
 // Config is the configuration for this trigger, and contains a hashmap with
 // generic settings. The key for each value should be lowercased always.
 type Config struct {
-	Id       string            `json:"id"`
-	Type     string            `json:"type"`
-	Settings map[string]string `json:"settings"`
+	Id       string                     `json:"id"`
+	Type     string                     `json:"type"`
+	Settings map[string]string          `json:"settings"`
+	Objects  map[string]*scanner.Object `json:"agentObjects"`
 }
 
 // Factory is the factory method for a trigger implementation module.

--- a/internal/trigger/webhook.go
+++ b/internal/trigger/webhook.go
@@ -113,7 +113,8 @@ func (s *WebhookTrigger) getUrl() (string, error) {
 // that body.
 func (s *WebhookTrigger) getBody() (io.ReadWriter, error) {
 	buf := new(bytes.Buffer)
-	body, err := RenderTemplate(s.config.Settings["body"], s.config.Settings)
+	bodyTemplateVars := mixinObjects(s.config.Settings, s.config.Objects)
+	body, err := RenderTemplate(s.config.Settings["body"], bodyTemplateVars)
 	if err != nil {
 		return buf, err
 	}
@@ -165,7 +166,8 @@ func (s *WebhookTrigger) getHeaders() (map[string]string, error) {
 		if flds[0] == "" || flds[1] == "" {
 			continue
 		}
-		val, err := RenderTemplate(flds[1], s.config.Settings)
+		headerTemplateVars := mixinObjects(s.config.Settings, s.config.Objects)
+		val, err := RenderTemplate(flds[1], headerTemplateVars)
 		if err != nil {
 			return headers, err
 		}


### PR DESCRIPTION
This adds a new "objects" item in template data. It contains info about 
objects, which triggered the webhook so that it could be used in 
body/header templates

TODO:
* [ ] Update webhook tests to make sure objects are passed to triggers correctly
* [ ] Update examples